### PR TITLE
feat: optimize camera input and do not treat as a tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+dist/
+node_modules/

--- a/src/index.html
+++ b/src/index.html
@@ -133,7 +133,7 @@
         #toolbar_L button:hover.panel_select { color: var(--btn-color-hover); text-decoration: underline; }
         #toolbar_L .sep { margin-top: 5px; border-top: 1px solid var(--borders); }
         #hover { z-index: 2200; display: none; bottom: 130px; left: 50%; margin-left: -17px; position: absolute; }
-        #hover .tool_camera { z-index: 2220; position: relative; padding: 5px; top: 32px; left: 0; border: 1px solid #717b8d40; border-radius: 3px; cursor: move; }
+        #hover .tool_frame_voxels { z-index: 2220; position: relative; padding: 5px; top: 32px; left: 0; border: 1px solid #717b8d40; border-radius: 3px; cursor: move; }
         #hover li { z-index: 2210; padding: 5px; background: var(--btn-bg); transition: all 0.2s ease-in-out; border: 1px solid #717b8d35; border-radius: 3px; position: absolute; cursor: pointer; }
         #hover li:hover { background: orange; }
         #hover li.tool_selector { background: orange; }
@@ -658,7 +658,7 @@
     </div>
 
     <div id="hover">
-        <button class="tool_camera"><i class="material-icons">control_camera</i></button>
+        <button class="tool_frame_voxels"><i class="material-icons">control_camera</i></button>
         <ul>
             <li class="tool_box_add hover_item_hide"><i class="material-icons">add</i></li>
             <li class="tool_box_remove hover_item_hide"><i class="material-icons">remove</i></li>
@@ -729,13 +729,12 @@
     <div id="shortcuts" ondblclick="this.style.display = 'none'">
         <table title="Double tap to close">
             <tr><th>Shortcut</th> <th>Description</th></tr>
-            <tr><td>SPACE / ALT</td> <td>Toggle Free Camera Tool (MODEL)</td></tr>
-            <tr><td>SPACE + CTRL</td> <td>Translate Free Camera (MODEL)</td></tr>
+            <tr><td>SPACE / ALT</td> <td>Toggle Frame Voxels Tool (MODEL)</td></tr>
             <tr><td>ENTER</td> <td>Apply Voxel Transforms (MODEL)</td></tr>
             <tr><td>DEL</td> <td>Delete Selected Voxels (Transform)</td></tr>
             <tr><td>DEL</td> <td>Delete Selected Bake (EXPORT)</td></tr>
-            <tr><td>` / C</td> <td>Free Camera Tool (MODEL)</td></tr>
             <tr><td>F</td> <td>Frame Camera (ALL MODES)</td></tr>
+            <tr><td>`</td> <td>Frame Voxels Tool (MODEL)</td></tr>
             <tr><td>F</td> <td>Frame Voxels (Transform)</td></tr>
             <tr><td>O</td> <td>Toggle Orthographic camera</td></tr>
             <tr><td>R</td> <td>Toggle Render tab</td></tr>

--- a/src/modules/interfaces/hover.js
+++ b/src/modules/interfaces/hover.js
@@ -50,7 +50,7 @@ class Hover {
 
         if (ev.target === hover.elemDrag) {
             hover.isActive = true;
-            tool.toolSelector('camera');
+            tool.toolSelector('frame_voxels');
         }
     }
 

--- a/src/modules/sandbox/sandbox.js
+++ b/src/modules/sandbox/sandbox.js
@@ -82,6 +82,11 @@ class Sandbox {
         this.camera.updateProjectionMatrix();
 
         this.controls = new OrbitControls(this.camera, renderer.domElement);
+        this.controls.mouseButtons = {
+            LEFT: THREE.MOUSE.NONE,    // left button: no action
+            MIDDLE: THREE.MOUSE.PAN,   // middle button: pan
+            RIGHT: THREE.MOUSE.ROTATE  // right button: rotate
+        };
         this.controls.minDistance = 2.0;
         this.controls.maxDistance = CAM_FAR;
         this.controls.zoomSpeed = 1.0;


### PR DESCRIPTION
Hi! :wave: I'm glad to find this **Great work**! :sparkles: I'm also interested in **building a web voxel engine** and **implementing some specific features** if I can (like converting Minecraft saves into editable voxels, importing LLM generated voxels, combining voxel models to a whole world, etc). Before that, can I develop this voxel-builder project **together with you**? If possible, I’d love to join as a contributor. :handshake:

If you agree, this first PR is about **input control of camera and tools**. **In modern game engines** (like Unity, UE and most DCC softwares), we usually control cameras by **middle button for panning** and **right button for rotation**. Currently in this project, **tools respond to all mouse input** and **camera control is defined as a separated tool**, which can be a bit inconvenient despite the available shortcuts.

I noticed you are working on version 4.6.0, so I **based my changes on 4.5.9 r4 to avoid conflicts**. If you’re open to my participation, I have more improvements to share, such as:  
- Bridge tool preview and make it end at mouse up position instead of the bounding box boundary  
- Continuous color selection  
- Allow rectangle tools to start from empty space (areas on the screen without any voxels), since most of them don’t require pick info  
- And more! :rocket:

By the way, I noticed that **core.js** contains too much logic. While I see you have already separated some modules, I wonder if further modularization might help with maintainability and scalability in the long run. (Just an advice 😄)

**Looking forward to your feedback and hopefully working together!**